### PR TITLE
Ignore YouTube links

### DIFF
--- a/urltitle.tcl
+++ b/urltitle.tcl
@@ -51,6 +51,7 @@ proc pubm:urltitle {nick host user chan text} {
 			if {[string match -nocase "*pastebin*" $word]} { break }
 			if {[string match -nocase "*google*" $word]} { break }
 			if {[string match -nocase "*wiki*" $word]} { break }
+			if {[string match -nocase "*youtube*" $word]} { break }
 			if {[string length $word] >= $urltitle(length) && \
 					[regexp -nocase {^((f|ht)tp(s|)://|www\.[^\.]+\.)} $word] && \
 					![regexp {://([^/:]*:([^/]*@|\d+(/|$))|.*/\.)} $word]} {


### PR DESCRIPTION
Will make Lain stop responding to YouTube links, this will stop both Lurk and Lain messaging the channel when a Youtube link is posted.
